### PR TITLE
allow minimum_coverage to be number or hash

### DIFF
--- a/lib/rspec/simplecov/configuration.rb
+++ b/lib/rspec/simplecov/configuration.rb
@@ -23,8 +23,10 @@ module RSpec
         @caller_path = backtrace[0].split(':').first
         @backtrace = backtrace
 
+        minimum_line_coverage = simplecov_instance.minimum_coverage
+        minimum_line_coverage = minimum_line_coverage[:line] if minimum_line_coverage.is_a?(Hash) 
         @context_text = "#minimum_coverage"
-        @test_case_text = "must be at least #{simplecov_instance.minimum_coverage[:line]}%"
+        @test_case_text = "must be at least #{minimum_line_coverage}%"
 
         Docile.dsl_eval( self, &block ) if block_given?
       end

--- a/lib/rspec/simplecov/setup.rb
+++ b/lib/rspec/simplecov/setup.rb
@@ -28,7 +28,8 @@ module RSpec
             minimum_coverage = configuration.described_thing.minimum_coverage
             configuration.described_thing.running = true
             
-            expect( result.covered_percent ).to be >= minimum_coverage[:line]
+            minimum_line_coverage = minimum_coverage.is_a?(Hash) ? minimum_coverage[:line] : minimum_coverage
+            expect( result.covered_percent ).to be >= minimum_line_coverage
           end
         end
 

--- a/lib/rspec/simplecov/version.rb
+++ b/lib/rspec/simplecov/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module SimpleCov
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end


### PR DESCRIPTION
In our configuration files we are setting minimum_coverage to 100, but the code seems to want a hash with a line property, so just allow both